### PR TITLE
Adding skip rules for open files by app_data\search

### DIFF
--- a/AzureWebAppClone/Program.cs
+++ b/AzureWebAppClone/Program.cs
@@ -151,7 +151,14 @@ namespace AzureWebAppClone
         }
         public static void SyncWebApps(Profile src, Profile dest)
         {
-            DeploymentSyncOptions syncOptions = new DeploymentSyncOptions();
+            DeploymentSyncOptions syncOptions = new DeploymentSyncOptions()
+            {
+                Rules =
+                {
+                    new DeploymentSkipRule("SkipASearch", "AddChild", "dirPath", "app.data.search", ""),
+                    new DeploymentSkipRule("SkipUSearch", "Update", "dirPath", "app.data.search", "")
+                }
+            };
 
             DeploymentBaseOptions sourceBaseOptions = new DeploymentBaseOptions();
             sourceBaseOptions.ComputerName = "https://" + src.publishUrl + "/msdeploy.axd";


### PR DESCRIPTION
Hey,

I've made this change to add rules to the web app sync process in order to skip the App_Data\Search folder. This folder always has opened files like write.lock

Hope it helps